### PR TITLE
Top Up Products

### DIFF
--- a/pretix_wallet/models.py
+++ b/pretix_wallet/models.py
@@ -46,7 +46,7 @@ def get_or_create_wallet_membership_type(organizer):
 
 def create_membership_if_not_existant(organizer, customer):
     membership_type = get_or_create_wallet_membership_type(organizer)
-    if not membership_type.memberships.filter(customer=customer).first():
+    if not membership_type.memberships.filter(customer=customer).exists():
         Membership.objects.create(
             testmode=False,
             customer=customer,

--- a/pretix_wallet/models.py
+++ b/pretix_wallet/models.py
@@ -40,7 +40,7 @@ def get_or_create_wallet_membership_type(organizer):
         organizer=organizer,
         allow_parallel_usage=True,
         transferable=False,
-        max_usages=False,
+        max_usages=None,
     )
 
 

--- a/pretix_wallet/models.py
+++ b/pretix_wallet/models.py
@@ -1,7 +1,56 @@
+import datetime
+
 from django.db import models
-from pretix.base.models import Customer, GiftCard
+from pretix.base.models import Customer, GiftCard, MembershipType, Membership
+from pretix.base.models.giftcards import gen_giftcard_secret
+
+VERY_FAR_FUTURE = datetime.date(2099, 12, 12)
 
 
 class CustomerWallet(models.Model):
     customer = models.OneToOneField(Customer, on_delete=models.CASCADE, related_name='wallet')
     giftcard = models.OneToOneField(GiftCard, on_delete=models.CASCADE, related_name='wallet')
+
+    @staticmethod
+    def create_if_non_existent(organizer, customer):
+        try:
+            _ = customer.wallet
+        except CustomerWallet.DoesNotExist:
+            giftcard = GiftCard.objects.create(
+                issuer=organizer,
+                currency="EUR",
+                conditions=f"Wallet for {customer.name_cached} ({customer.email})",
+                secret=f"{customer.email.split('@')[0]}-{gen_giftcard_secret(length=organizer.settings.giftcard_length)}")
+            CustomerWallet.objects.create(customer=customer, giftcard=giftcard)
+        create_membership_if_not_existant(organizer, customer)
+
+
+def membership_type_name_for_organizer(organizer):
+    return f"{organizer.name} Wallet"
+
+
+def get_or_create_wallet_membership_type(organizer):
+    membership_type = organizer.membership_types.filter(name=membership_type_name_for_organizer(organizer)).first()
+
+    if membership_type is not None:
+        return membership_type
+
+    return MembershipType.objects.create(
+        name=membership_type_name_for_organizer(organizer),
+        organizer=organizer,
+        allow_parallel_usage=True,
+        transferable=False,
+        max_usages=False,
+    )
+
+
+def create_membership_if_not_existant(organizer, customer):
+    membership_type = get_or_create_wallet_membership_type(organizer)
+    if not membership_type.memberships.filter(customer=customer).first():
+        Membership.objects.create(
+            testmode=False,
+            customer=customer,
+            membership_type=membership_type,
+            date_start=datetime.date.today(),
+            date_end=VERY_FAR_FUTURE
+        )

--- a/pretix_wallet/payment.py
+++ b/pretix_wallet/payment.py
@@ -141,7 +141,7 @@ class WalletPaymentProvider(GiftCardPayment):
             #     choices=product_choices))
         ])
 
-def _wallet_transaction(event, payment: OrderPayment, gift_card: GiftCard, sign=-1):
+def _wallet_transaction(event, payment: OrderPayment, gift_card: GiftCard, sign=-1, amount=None):
     with transaction.atomic():
         if gift_card.currency != event.currency:  # noqa - just a safeguard
             raise PaymentException(_("This gift card does not support this currency."))
@@ -149,12 +149,8 @@ def _wallet_transaction(event, payment: OrderPayment, gift_card: GiftCard, sign=
             raise PaymentException(_("This gift card is not accepted by this event organizer."))
 
         return gift_card.transactions.create(
-            value=sign * payment.amount,
+            value=sign * (amount if amount else payment.amount),
             order=payment.order,
             payment=payment,
             acceptor=event.organizer,
         )
-def position_is_top_up_product(event, position):
-    top_up_products = event.settings.get("payment_wallet_top_up_products").lower().split(',')
-    product_name = position.item.name.localize('en').lower()
-    return product_name in top_up_products

--- a/pretix_wallet/payment.py
+++ b/pretix_wallet/payment.py
@@ -77,9 +77,6 @@ class WalletPaymentProvider(GiftCardPayment):
             'retry': True
         }
 
-
-
-
     def execute_payment(self, request: HttpRequest, payment: OrderPayment, is_early_special_case=False) -> str:
         # re-implemented as the original method does not allow for giftcards to have negative balance
 
@@ -128,7 +125,8 @@ class WalletPaymentProvider(GiftCardPayment):
             ('top_up_products', CharField(
                 label=_("Products used to charge wallet accounts"),
                 help_text=_(
-                  "Comma separated list of English product names, Buying these products will charge a users wallet by their price. Remeber, to require the Wallet memberships for these products to force users to login."),
+                    "Comma separated list of English product names, Buying these products will charge a users wallet by"
+                    "their price. Remeber, to require the Wallet memberships for these products to force users to login."),
             ))
             # ('top_up_products', MultipleChoiceField(
             #     widget=CheckboxSelectMultiple,
@@ -140,6 +138,7 @@ class WalletPaymentProvider(GiftCardPayment):
             #         "Buying these products will charge a users wallet by their price. Remeber, to require the Wallet memberships for these products to force users to login."),
             #     choices=product_choices))
         ])
+
 
 def _wallet_transaction(event, payment: OrderPayment, gift_card: GiftCard, sign=-1, amount=None):
     with transaction.atomic():

--- a/pretix_wallet/payment.py
+++ b/pretix_wallet/payment.py
@@ -1,10 +1,11 @@
+import ast
 from _decimal import Decimal
 from collections import OrderedDict
 from typing import Dict, Any, Union
 
 from django.contrib import messages
 from django.db import transaction
-from django.forms import CharField
+from django.forms import CharField, MultipleChoiceField, CheckboxSelectMultiple
 from django.http import HttpRequest
 from django.utils.crypto import get_random_string
 from django.utils.translation import gettext_lazy as _
@@ -13,6 +14,7 @@ from pretix.base.models import Order, OrderPayment, GiftCard
 from pretix.base.models.customers import CustomerSSOProvider
 from pretix.base.payment import PaymentException, GiftCardPayment
 from pretix.base.services.cart import add_payment_to_cart
+from pretix.control.forms.item import ItemVariationForm
 from pretix.helpers import OF_SELF
 from pretix.multidomain.urlreverse import build_absolute_uri
 from pretix.presale.views.cart import cart_session
@@ -25,10 +27,10 @@ class WalletPaymentProvider(GiftCardPayment):
     verbose_name = _("Wallet")
     public_name = _("Wallet")
 
-    def payment_form_render(self, request: HttpRequest, total: Decimal, order: Order=None) -> str:
+    def payment_form_render(self, request: HttpRequest, total: Decimal, order: Order = None) -> str:
         return "Wallet payment form"
 
-    def checkout_confirm_render(self, request, order: Order=None, info_data: dict=None) -> str:
+    def checkout_confirm_render(self, request, order: Order = None, info_data: dict = None) -> str:
         return "Wallet confirm"
 
     def checkout_prepare(self, request: HttpRequest, cart: Dict[str, Any]) -> Union[bool, str]:
@@ -37,7 +39,8 @@ class WalletPaymentProvider(GiftCardPayment):
                 messages.error(request, _("You do not have a wallet."))
                 return False
             if request.customer.wallet.giftcard.value < 0:
-                messages.error(request, _("Your wallet has a negative balance. Please top it up or use another payment method."))
+                messages.error(request,
+                               _("Your wallet has a negative balance. Please top it up or use another payment method."))
                 return False
             cart_session(request)
             add_payment_to_cart(
@@ -47,7 +50,8 @@ class WalletPaymentProvider(GiftCardPayment):
                 info_data=self._get_payment_info_data(request.customer.wallet),
             )
             return True
-        return self._redirect_user(request, build_absolute_uri(request.event, "presale:event.checkout", kwargs={"step": "payment"}))
+        return self._redirect_user(request, build_absolute_uri(request.event, "presale:event.checkout",
+                                                               kwargs={"step": "payment"}))
 
     def _redirect_user(self, request: HttpRequest, next_url: str):
         provider = CustomerSSOProvider.objects.last()
@@ -73,6 +77,9 @@ class WalletPaymentProvider(GiftCardPayment):
             'retry': True
         }
 
+
+
+
     def execute_payment(self, request: HttpRequest, payment: OrderPayment, is_early_special_case=False) -> str:
         # re-implemented as the original method does not allow for giftcards to have negative balance
 
@@ -80,24 +87,15 @@ class WalletPaymentProvider(GiftCardPayment):
         if not gcpk:
             raise PaymentException("Invalid state, should never occur.")
         try:
-            with transaction.atomic():
-                try:
-                    gc = GiftCard.objects.select_for_update(of=OF_SELF).get(pk=gcpk)
-                except GiftCard.DoesNotExist:
-                    raise PaymentException(_("This gift card does not support this currency."))
-                if gc.currency != self.event.currency:  # noqa - just a safeguard
-                    raise PaymentException(_("This gift card does not support this currency."))
-                if not gc.accepted_by(self.event.organizer):
-                    raise PaymentException(_("This gift card is not accepted by this event organizer."))
+            try:
+                gc = GiftCard.objects.select_for_update(of=OF_SELF).get(pk=gcpk)
+            except GiftCard.DoesNotExist:
+                raise PaymentException(_("This gift card does not support this currency."))
 
-                trans = gc.transactions.create(
-                    value=-1 * payment.amount,
-                    order=payment.order,
-                    payment=payment,
-                    acceptor=self.event.organizer,
-                )
-                payment.info_data['transaction_id'] = trans.pk
-                payment.confirm(send_mail=not is_early_special_case, generate_invoice=not is_early_special_case)
+            trans = _wallet_transaction(self.event, payment, gc)
+            payment.info_data['transaction_id'] = trans.pk
+            payment.confirm(send_mail=not is_early_special_case, generate_invoice=not is_early_special_case)
+
         except PaymentException as e:
             payment.fail(info={'error': str(e)})
             raise e
@@ -108,7 +106,8 @@ class WalletPaymentProvider(GiftCardPayment):
                 messages.error(request, _("You do not have a wallet."))
                 return False
             if request.customer.wallet.giftcard.value < 0:
-                messages.error(request, _("Your wallet has a negative balance. Please top it up or use another payment method."))
+                messages.error(request,
+                               _("Your wallet has a negative balance. Please top it up or use another payment method."))
                 return False
             gc = request.customer.wallet.giftcard
             if gc not in self.event.organizer.accepted_gift_cards:
@@ -121,6 +120,41 @@ class WalletPaymentProvider(GiftCardPayment):
 
     @property
     def settings_form_fields(self):
+        product_choices = list(map(lambda product: (str(product.pk), product.name), self.event.items.all()))
+
         return OrderedDict(list(super().settings_form_fields.items()) + [
-            ('api_key', CharField(label=_("API key"), help_text=_("The API key that the terminal uses to authenticate against the POS api provided by this plugin."))),
+            ('api_key', CharField(label=_("API key"), help_text=_(
+                "The API key that the terminal uses to authenticate against the POS api provided by this plugin."))),
+            ('top_up_products', CharField(
+                label=_("Products used to charge wallet accounts"),
+                help_text=_(
+                  "Comma separated list of English product names, Buying these products will charge a users wallet by their price. Remeber, to require the Wallet memberships for these products to force users to login."),
+            ))
+            # ('top_up_products', MultipleChoiceField(
+            #     widget=CheckboxSelectMultiple,
+            #     label=_("Products used to charge wallet accounts"),
+            #     required=False,
+            #     initial=[0],
+            #     # initial=ast.literal_eval(self.event.settings.get('payment_wallet_top_up_products')),
+            #     help_text=_(
+            #         "Buying these products will charge a users wallet by their price. Remeber, to require the Wallet memberships for these products to force users to login."),
+            #     choices=product_choices))
         ])
+
+def _wallet_transaction(event, payment: OrderPayment, gift_card: GiftCard, sign=-1):
+    with transaction.atomic():
+        if gift_card.currency != event.currency:  # noqa - just a safeguard
+            raise PaymentException(_("This gift card does not support this currency."))
+        if not gift_card.accepted_by(event.organizer):
+            raise PaymentException(_("This gift card is not accepted by this event organizer."))
+
+        return gift_card.transactions.create(
+            value=sign * payment.amount,
+            order=payment.order,
+            payment=payment,
+            acceptor=event.organizer,
+        )
+def position_is_top_up_product(event, position):
+    top_up_products = event.settings.get("payment_wallet_top_up_products").lower().split(',')
+    product_name = position.item.name.localize('en').lower()
+    return product_name in top_up_products

--- a/pretix_wallet/signals.py
+++ b/pretix_wallet/signals.py
@@ -1,7 +1,15 @@
+from django.core.exceptions import ImproperlyConfigured
 from django.dispatch import receiver
+from django.http import Http404
+from django.utils.functional import cached_property
+from django.utils.translation import gettext_lazy as _
 
 from pretix.base.payment import PaymentException
 from pretix.base.signals import register_payment_providers, order_paid
+from pretix.helpers.http import redirect_to_url
+from pretix.presale.checkoutflow import BaseCheckoutFlowStep, CartMixin, TemplateFlowStep
+from pretix.presale.signals import checkout_flow_steps
+from pretix.presale.views.cart import cart_session
 from pretix_wallet.models import CustomerWallet
 
 from pretix_wallet.payment import WalletPaymentProvider, _wallet_transaction
@@ -12,17 +20,55 @@ def register_payment_provider(sender, **kwargs):
     return [WalletPaymentProvider]
 
 
+@receiver(checkout_flow_steps, dispatch_uid="checkout_flow_steps_wallet")
+def wallet_checkout_flow_steps(sender, **kwargs):
+    return MembershipGrantingCheckoutFlowStep
+
+
 @receiver(order_paid, dispatch_uid="payment_wallet_order_paid")
 def wallet_order_paid(sender, order, **kwargs):
-    top_up_positions = list(filter(lambda pos: position_is_top_up_product(pos), order.positions))
+    top_up_positions = list(filter(lambda pos: position_is_top_up_product(sender, pos), order.positions.all()))
     if top_up_positions:
         CustomerWallet.create_if_non_existent(sender.organizer, order.customer)
         try:
-            top_up_value = sum(lambda pos: pos.price, top_up_positions)
+            top_up_value = sum(map(lambda pos: pos.price, top_up_positions))
             _wallet_transaction(sender, order.payments.last(), order.customer.wallet.giftcard, sign=1,
                                 amount=top_up_value)
         except PaymentException as e:
             raise e
+
+
+class MembershipGrantingCheckoutFlowStep(CartMixin, BaseCheckoutFlowStep):
+    icon = 'user-plus'
+    identifier = 'wallet-membership-granting'
+
+    def label(self):
+        return _('Creating Wallet')
+
+    @cached_property
+    def priority(self):
+        # One less than MembershipStep
+        return 46
+
+    def get(self, request):
+        if request.event.organizer and request.customer:
+            CustomerWallet.create_if_non_existent(request.event.organizer, request.customer)
+            return redirect_to_url(self.get_next_url(request))
+        else:
+            raise ImproperlyConfigured('User reached the wallet creation step without signing in.'
+                                       'Have you created customer accounts and required membership'
+                                       'for the top-up product?')
+
+    def is_completed(self, request, warn=False):
+        if self.request.customer.wallet:
+            return True
+        return False
+
+    def is_applicable(self, request):
+        self.request = request
+        if not request.event.settings.get("payment_wallet_top_up_products"):
+            return False
+        return any(map(lambda pos: position_is_top_up_product(request.event, pos), self.positions))
 
 
 def position_is_top_up_product(event, position):

--- a/pretix_wallet/signals.py
+++ b/pretix_wallet/signals.py
@@ -1,9 +1,18 @@
 from django.dispatch import receiver
-from pretix.base.signals import register_payment_providers
 
-from pretix_wallet.payment import WalletPaymentProvider
+from pretix.base.payment import PaymentException
+from pretix.base.signals import register_payment_providers, order_paid
+
+from pretix_wallet.payment import WalletPaymentProvider, _wallet_transaction
 
 
 @receiver(register_payment_providers, dispatch_uid="payment_wallet")
 def register_payment_provider(sender, **kwargs):
     return [WalletPaymentProvider]
+
+@receiver(order_paid, dispatch_uid="payment_wallet_order_paid")
+def wallet_order_paid(sender, order, **kwargs):
+    try:
+        _wallet_transaction(sender, order.payments.last(), order.customer.wallet.giftcard, sign=1)
+    except PaymentException as e:
+        raise e

--- a/pretix_wallet/signals.py
+++ b/pretix_wallet/signals.py
@@ -72,6 +72,8 @@ class MembershipGrantingCheckoutFlowStep(CartMixin, BaseCheckoutFlowStep):
 
 
 def position_is_top_up_product(event, position):
+    if not event.settings.get("payment_wallet_top_up_products"):
+        return False
     top_up_products = event.settings.get("payment_wallet_top_up_products").lower().split(',')
     product_name = position.item.name.localize('en').lower()
     return product_name in top_up_products

--- a/pretix_wallet/signals.py
+++ b/pretix_wallet/signals.py
@@ -2,6 +2,7 @@ from django.dispatch import receiver
 
 from pretix.base.payment import PaymentException
 from pretix.base.signals import register_payment_providers, order_paid
+from pretix_wallet.models import CustomerWallet
 
 from pretix_wallet.payment import WalletPaymentProvider, _wallet_transaction
 
@@ -10,8 +11,10 @@ from pretix_wallet.payment import WalletPaymentProvider, _wallet_transaction
 def register_payment_provider(sender, **kwargs):
     return [WalletPaymentProvider]
 
+
 @receiver(order_paid, dispatch_uid="payment_wallet_order_paid")
 def wallet_order_paid(sender, order, **kwargs):
+    CustomerWallet.create_if_non_existent(sender.organizer, order.customer)
     try:
         _wallet_transaction(sender, order.payments.last(), order.customer.wallet.giftcard, sign=1)
     except PaymentException as e:

--- a/pretix_wallet/urls.py
+++ b/pretix_wallet/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from pretix.api.urls import event_router
 
 from pretix_wallet.views import TransactionListView, ProductViewSet, WalletViewSet, TransactionViewSet, PairingView, \
-    RemovePairingView
+    RemovePairingView, WalletRequiredRedirectView
 
 app_name = 'pretix_wallet'
 
@@ -12,6 +12,7 @@ event_router.register(r'wallet/pos/wallets/token/(?P<token_id>[^/.]+)/transactio
 
 organizer_patterns = [
     path('account/wallet/', TransactionListView.as_view(), name='wallet'),
+    path('account/wallet/login', WalletRequiredRedirectView.as_view(), name='wallet_login'),
     path('account/wallet/pair/<str:token_id>/', PairingView.as_view(), name='pair'),
     path('account/wallet/unpair/', RemovePairingView.as_view(), name='unpair'),
 ]


### PR DESCRIPTION
By marking a pretix products as "top up", buying them will charge a users wallet by their value. This PR also introduces a wallet membership type, automatically creates and assigns it to wallet users. You can use this to ensure users buying top up products are forced to sign in.

It also introduces a redirect url route using which you can funnel users through the wallet login and them redirect them to an arbitrary target. This is useful for linking users to top-up shops since it ensures the correct data (user, wallet, membership type, membership) are created before the user enters the shop.